### PR TITLE
Use Constant highlighting for nil

### DIFF
--- a/syntax/lox.vim
+++ b/syntax/lox.vim
@@ -13,6 +13,9 @@
 " booleans
 :syntax keyword loxBoolean true false
 
+" constants
+:syntax keyword loxConstant nil
+
 " functions
 :syntax keyword loxFunction print 
 
@@ -38,6 +41,7 @@
 
 :highlight link loxKeyword Keyword
 :highlight link loxBoolean Boolean
+:highlight link loxConstant Constant
 :highlight link loxFunction Function
 :highlight link loxOperator Operator
 :highlight link loxConditional Conditional


### PR DESCRIPTION
`nil` should be highlighted using the [`Constant` syntax group][group-name]. This matches how `null` would be highlighted in a language like Java.

**Before**:
<img width="147" alt="screenshot of vim buffer with no highlighting for nil" src="https://user-images.githubusercontent.com/2294397/155848659-84007680-9785-4e05-b2f0-8a01a6c361d5.png">

**After**:
<img width="147" alt="screenshot of vim buffer with highlighted nil" src="https://user-images.githubusercontent.com/2294397/155848669-9ea44475-883b-46e9-af68-0388aee9a7a0.png">

[group-name]: http://vimdoc.sourceforge.net/htmldoc/syntax.html#group-name
